### PR TITLE
Initialize roll-model serverless backend with CDK, Lambdas, and single-table DynamoDB

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true,
+    jest: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json'
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier'
+  ],
+  rules: {
+    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
+    '@typescript-eslint/no-floating-promises': 'error',
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true }
+      }
+    ]
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+cdk.out/
+coverage/
+*.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# roll-model backend
+
+Production-grade serverless backend for the **roll-model** scientific training intelligence platform for grapplers.
+
+## Project overview
+
+This repository initializes the backend foundation with strict TypeScript, AWS CDK v2 infrastructure, and modular Lambda handlers.
+
+Core principles implemented:
+- Athlete owns their training data.
+- Coaches can comment but cannot alter or delete athlete entries.
+- Structured-first storage for analytics and ML-readiness.
+- JSON export available from day one.
+
+## Architecture summary
+
+- **AWS CDK v2 (TypeScript)** provisions all cloud resources.
+- **API Gateway REST API** for HTTP interface.
+- **Cognito User Pool** for JWT auth (`custom:role` claim for `athlete | coach`).
+- **Lambda (Node.js 20)** for business logic.
+- **DynamoDB single-table (`RollModel`)** for user, entry, link, and comment entities.
+
+Repository layout:
+
+```text
+backend/
+  lambdas/
+  shared/
+infrastructure/
+  cdk/
+docs/
+```
+
+## Environment setup
+
+1. Install Node.js 20+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Build project:
+   ```bash
+   npm run build
+   ```
+4. Run tests:
+   ```bash
+   npm test
+   ```
+5. Run lint:
+   ```bash
+   npm run lint
+   ```
+
+## Deploy with CDK
+
+Configure AWS credentials and default region/account, then run:
+
+```bash
+npm run cdk:deploy
+```
+
+To preview synthesized infrastructure:
+
+```bash
+npm run cdk:synth
+```
+
+## Documentation
+
+- Data model: `docs/data-model.md`
+- API contracts: `docs/api-contracts.md`

--- a/backend/lambdas/createEntry/index.test.ts
+++ b/backend/lambdas/createEntry/index.test.ts
@@ -1,0 +1,42 @@
+import { buildEntry } from './index';
+
+describe('buildEntry', () => {
+  it('builds an entry with expected shape', () => {
+    const entry = buildEntry(
+      'athlete-1',
+      {
+        sections: {
+          private: 'private reflection',
+          shared: 'shareable notes'
+        },
+        sessionMetrics: {
+          durationMinutes: 75,
+          intensity: 8,
+          rounds: 6,
+          giOrNoGi: 'gi',
+          tags: ['guard', 'sweeps']
+        }
+      },
+      '2026-01-01T00:00:00.000Z',
+      'entry-123'
+    );
+
+    expect(entry).toEqual({
+      entryId: 'entry-123',
+      athleteId: 'athlete-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      sections: {
+        private: 'private reflection',
+        shared: 'shareable notes'
+      },
+      sessionMetrics: {
+        durationMinutes: 75,
+        intensity: 8,
+        rounds: 6,
+        giOrNoGi: 'gi',
+        tags: ['guard', 'sweeps']
+      }
+    });
+  });
+});

--- a/backend/lambdas/createEntry/index.ts
+++ b/backend/lambdas/createEntry/index.ts
@@ -1,0 +1,87 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyHandler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+
+import { getAuthContext, requireRole } from '../../shared/auth';
+import { putItem } from '../../shared/db';
+import { ApiError, errorResponse, response } from '../../shared/responses';
+import type { CreateEntryRequest, Entry } from '../../shared/types';
+
+const parseBody = (event: APIGatewayProxyEvent): CreateEntryRequest => {
+  if (!event.body) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'Request body is required.',
+      statusCode: 400
+    });
+  }
+
+  const parsed = JSON.parse(event.body) as Partial<CreateEntryRequest>;
+
+  if (
+    !parsed.sections ||
+    typeof parsed.sections.private !== 'string' ||
+    typeof parsed.sections.shared !== 'string' ||
+    !parsed.sessionMetrics ||
+    typeof parsed.sessionMetrics.durationMinutes !== 'number' ||
+    typeof parsed.sessionMetrics.intensity !== 'number' ||
+    typeof parsed.sessionMetrics.rounds !== 'number' ||
+    typeof parsed.sessionMetrics.giOrNoGi !== 'string' ||
+    !Array.isArray(parsed.sessionMetrics.tags)
+  ) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'Entry payload is invalid.',
+      statusCode: 400
+    });
+  }
+
+  return parsed as CreateEntryRequest;
+};
+
+export const buildEntry = (
+  athleteId: string,
+  input: CreateEntryRequest,
+  nowIso: string,
+  entryId = uuidv4()
+): Entry => ({
+  entryId,
+  athleteId,
+  createdAt: nowIso,
+  updatedAt: nowIso,
+  sections: input.sections,
+  sessionMetrics: input.sessionMetrics
+});
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    requireRole(auth, ['athlete']);
+
+    const payload = parseBody(event);
+    const nowIso = new Date().toISOString();
+    const entry = buildEntry(auth.userId, payload, nowIso);
+
+    await putItem({
+      Item: {
+        PK: `USER#${auth.userId}`,
+        SK: `ENTRY#${entry.createdAt}#${entry.entryId}`,
+        entityType: 'ENTRY',
+        ...entry
+      }
+    });
+
+    await putItem({
+      Item: {
+        PK: `ENTRY#${entry.entryId}`,
+        SK: 'META',
+        entityType: 'ENTRY_META',
+        athleteId: auth.userId,
+        createdAt: entry.createdAt
+      }
+    });
+
+    return response(201, { entry });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/backend/lambdas/exportData/index.ts
+++ b/backend/lambdas/exportData/index.ts
@@ -1,0 +1,91 @@
+import type { APIGatewayProxyHandler } from 'aws-lambda';
+
+import { getAuthContext, requireRole } from '../../shared/auth';
+import { queryItems } from '../../shared/db';
+import { errorResponse, response } from '../../shared/responses';
+import type { Comment, Entry } from '../../shared/types';
+
+interface EntryWithComments extends Entry {
+  comments: Comment[];
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    requireRole(auth, ['athlete']);
+
+    const entriesResult = await queryItems({
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :entryPrefix)',
+      ExpressionAttributeValues: {
+        ':pk': `USER#${auth.userId}`,
+        ':entryPrefix': 'ENTRY#'
+      }
+    });
+
+    const entries = (entriesResult.Items ?? [])
+      .filter((item) => item.entityType === 'ENTRY')
+      .map((item) => {
+        const { PK: _pk, SK: _sk, entityType: _entityType, ...entry } = item as Entry & {
+          PK: string;
+          SK: string;
+          entityType: string;
+        };
+        return entry;
+      });
+
+    const commentsByEntryId = new Map<string, Comment[]>();
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const commentsResult = await queryItems({
+          KeyConditionExpression: 'PK = :pk AND begins_with(SK, :commentPrefix)',
+          ExpressionAttributeValues: {
+            ':pk': `ENTRY#${entry.entryId}`,
+            ':commentPrefix': 'COMMENT#'
+          }
+        });
+
+        const comments = (commentsResult.Items ?? []).map((item) => {
+          const { PK: _pk, SK: _sk, entityType: _entityType, ...comment } = item as Comment & {
+            PK: string;
+            SK: string;
+            entityType: string;
+          };
+          return comment;
+        });
+
+        commentsByEntryId.set(entry.entryId, comments);
+      })
+    );
+
+    const fullExport = {
+      athleteId: auth.userId,
+      exportedAt: new Date().toISOString(),
+      entries: entries.map((entry) => ({
+        ...entry,
+        comments: commentsByEntryId.get(entry.entryId) ?? []
+      }))
+    };
+
+    const tidyExport = {
+      athlete: {
+        athleteId: auth.userId
+      },
+      entries,
+      comments: Array.from(commentsByEntryId.values()).flat(),
+      relationships: {
+        entryComments: entries.map((entry) => ({
+          entryId: entry.entryId,
+          commentIds: (commentsByEntryId.get(entry.entryId) ?? []).map((comment) => comment.commentId)
+        }))
+      }
+    };
+
+    return response(200, {
+      full: fullExport,
+      tidy: tidyExport
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/backend/lambdas/getEntries/index.ts
+++ b/backend/lambdas/getEntries/index.ts
@@ -1,0 +1,74 @@
+import type { APIGatewayProxyHandler } from 'aws-lambda';
+
+import { getAuthContext, requireRole } from '../../shared/auth';
+import { getItem, queryItems } from '../../shared/db';
+import { ApiError, errorResponse, response } from '../../shared/responses';
+import type { Entry } from '../../shared/types';
+
+const sanitizeForCoach = (entry: Entry): Omit<Entry, 'sections'> & { sections: { shared: string } } => ({
+  ...entry,
+  sections: {
+    shared: entry.sections.shared
+  }
+});
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    requireRole(auth, ['athlete', 'coach']);
+
+    const requestedAthleteId = event.pathParameters?.athleteId;
+    const athleteId = auth.role === 'athlete' ? auth.userId : requestedAthleteId;
+
+    if (!athleteId) {
+      throw new ApiError({
+        code: 'INVALID_REQUEST',
+        message: 'athleteId is required for coach requests.',
+        statusCode: 400
+      });
+    }
+
+    if (auth.role === 'coach') {
+      const link = await getItem({
+        Key: {
+          PK: `USER#${athleteId}`,
+          SK: `COACH#${auth.userId}`
+        }
+      });
+
+      if (!link.Item) {
+        throw new ApiError({
+          code: 'FORBIDDEN',
+          message: 'Coach is not linked to this athlete.',
+          statusCode: 403
+        });
+      }
+    }
+
+    const queryResult = await queryItems({
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :entryPrefix)',
+      ExpressionAttributeValues: {
+        ':pk': `USER#${athleteId}`,
+        ':entryPrefix': 'ENTRY#'
+      },
+      ScanIndexForward: false
+    });
+
+    const entries = (queryResult.Items ?? [])
+      .filter((item) => item.entityType === 'ENTRY')
+      .map((item) => {
+        const { PK: _pk, SK: _sk, entityType: _entityType, ...entry } = item as Entry & {
+          PK: string;
+          SK: string;
+          entityType: string;
+        };
+        return entry;
+      });
+
+    return response(200, {
+      entries: auth.role === 'coach' ? entries.map(sanitizeForCoach) : entries
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/backend/lambdas/linkCoachAthlete/index.ts
+++ b/backend/lambdas/linkCoachAthlete/index.ts
@@ -1,0 +1,58 @@
+import type { APIGatewayProxyHandler } from 'aws-lambda';
+
+import { getAuthContext, requireRole } from '../../shared/auth';
+import { putItem } from '../../shared/db';
+import { ApiError, errorResponse, response } from '../../shared/responses';
+
+interface LinkCoachAthleteRequest {
+  coachId: string;
+}
+
+const parseBody = (rawBody: string | null): LinkCoachAthleteRequest => {
+  if (!rawBody) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'Request body is required.',
+      statusCode: 400
+    });
+  }
+
+  const parsed = JSON.parse(rawBody) as Partial<LinkCoachAthleteRequest>;
+  if (typeof parsed.coachId !== 'string' || parsed.coachId.length === 0) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'coachId is required.',
+      statusCode: 400
+    });
+  }
+
+  return parsed as LinkCoachAthleteRequest;
+};
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    requireRole(auth, ['athlete']);
+
+    const payload = parseBody(event.body);
+
+    await putItem({
+      Item: {
+        PK: `USER#${auth.userId}`,
+        SK: `COACH#${payload.coachId}`,
+        entityType: 'COACH_LINK',
+        athleteId: auth.userId,
+        coachId: payload.coachId,
+        createdAt: new Date().toISOString()
+      }
+    });
+
+    return response(201, {
+      linked: true,
+      athleteId: auth.userId,
+      coachId: payload.coachId
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/backend/lambdas/postComment/index.ts
+++ b/backend/lambdas/postComment/index.ts
@@ -1,0 +1,88 @@
+import type { APIGatewayProxyHandler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+
+import { getAuthContext, requireRole } from '../../shared/auth';
+import { getItem, putItem } from '../../shared/db';
+import { ApiError, errorResponse, response } from '../../shared/responses';
+import type { Comment, PostCommentRequest } from '../../shared/types';
+
+const parseBody = (rawBody: string | null): PostCommentRequest => {
+  if (!rawBody) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'Request body is required.',
+      statusCode: 400
+    });
+  }
+
+  const parsed = JSON.parse(rawBody) as Partial<PostCommentRequest>;
+  if (typeof parsed.entryId !== 'string' || typeof parsed.body !== 'string' || parsed.body.length === 0) {
+    throw new ApiError({
+      code: 'INVALID_REQUEST',
+      message: 'Comment payload is invalid.',
+      statusCode: 400
+    });
+  }
+
+  return parsed as PostCommentRequest;
+};
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    requireRole(auth, ['coach']);
+
+    const payload = parseBody(event.body);
+    const entryMeta = await getItem({
+      Key: {
+        PK: `ENTRY#${payload.entryId}`,
+        SK: 'META'
+      }
+    });
+
+    if (!entryMeta.Item || typeof entryMeta.Item.athleteId !== 'string') {
+      throw new ApiError({
+        code: 'NOT_FOUND',
+        message: 'Entry not found.',
+        statusCode: 404
+      });
+    }
+
+    const link = await getItem({
+      Key: {
+        PK: `USER#${entryMeta.Item.athleteId}`,
+        SK: `COACH#${auth.userId}`
+      }
+    });
+
+    if (!link.Item) {
+      throw new ApiError({
+        code: 'FORBIDDEN',
+        message: 'Coach is not linked to this athlete.',
+        statusCode: 403
+      });
+    }
+
+    const comment: Comment = {
+      commentId: uuidv4(),
+      entryId: payload.entryId,
+      coachId: auth.userId,
+      createdAt: new Date().toISOString(),
+      body: payload.body,
+      visibility: 'visible'
+    };
+
+    await putItem({
+      Item: {
+        PK: `ENTRY#${comment.entryId}`,
+        SK: `COMMENT#${comment.createdAt}#${comment.commentId}`,
+        entityType: 'COMMENT',
+        ...comment
+      }
+    });
+
+    return response(201, { comment });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/backend/shared/auth.ts
+++ b/backend/shared/auth.ts
@@ -1,0 +1,50 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+import { ApiError } from './responses';
+import type { UserRole } from './types';
+
+export interface AuthContext {
+  userId: string;
+  role: UserRole;
+}
+
+const parseRole = (rawRole: string): UserRole => {
+  if (rawRole === 'athlete' || rawRole === 'coach') {
+    return rawRole;
+  }
+
+  throw new ApiError({
+    code: 'INVALID_ROLE',
+    message: 'User role is invalid.',
+    statusCode: 403
+  });
+};
+
+export const getAuthContext = (event: APIGatewayProxyEvent): AuthContext => {
+  const claims = event.requestContext.authorizer?.claims;
+  const userId = claims?.sub;
+  const roleClaim = claims?.['custom:role'];
+
+  if (!userId || !roleClaim) {
+    throw new ApiError({
+      code: 'UNAUTHORIZED',
+      message: 'Missing authentication claims.',
+      statusCode: 401
+    });
+  }
+
+  return {
+    userId,
+    role: parseRole(roleClaim)
+  };
+};
+
+export const requireRole = (auth: AuthContext, allowedRoles: UserRole[]): void => {
+  if (!allowedRoles.includes(auth.role)) {
+    throw new ApiError({
+      code: 'FORBIDDEN',
+      message: 'User does not have permission for this action.',
+      statusCode: 403
+    });
+  }
+};

--- a/backend/shared/db.ts
+++ b/backend/shared/db.ts
@@ -1,0 +1,58 @@
+import {
+  DynamoDBClient,
+  type DynamoDBClientConfig
+} from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  type GetCommandInput,
+  type GetCommandOutput,
+  PutCommand,
+  type PutCommandInput,
+  QueryCommand,
+  type QueryCommandInput,
+  type QueryCommandOutput
+} from '@aws-sdk/lib-dynamodb';
+
+const createDocumentClient = (): DynamoDBDocumentClient => {
+  const config: DynamoDBClientConfig = {};
+  const client = new DynamoDBClient(config);
+  return DynamoDBDocumentClient.from(client, {
+    marshallOptions: {
+      removeUndefinedValues: true
+    }
+  });
+};
+
+const documentClient = createDocumentClient();
+
+export const TABLE_NAME = process.env.TABLE_NAME ?? 'RollModel';
+
+export const putItem = async (input: Omit<PutCommandInput, 'TableName'>): Promise<void> => {
+  await documentClient.send(
+    new PutCommand({
+      TableName: TABLE_NAME,
+      ...input
+    })
+  );
+};
+
+export const queryItems = async (
+  input: Omit<QueryCommandInput, 'TableName'>
+): Promise<QueryCommandOutput> => {
+  return documentClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      ...input
+    })
+  );
+};
+
+export const getItem = async (input: Omit<GetCommandInput, 'TableName'>): Promise<GetCommandOutput> => {
+  return documentClient.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      ...input
+    })
+  );
+};

--- a/backend/shared/responses.ts
+++ b/backend/shared/responses.ts
@@ -1,0 +1,40 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+
+import type { ApiErrorShape } from './types';
+
+export class ApiError extends Error {
+  public readonly code: string;
+  public readonly statusCode: number;
+
+  public constructor(error: ApiErrorShape) {
+    super(error.message);
+    this.code = error.code;
+    this.statusCode = error.statusCode;
+  }
+}
+
+export const response = <T>(statusCode: number, payload: T): APIGatewayProxyResult => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify(payload)
+});
+
+export const errorResponse = (error: unknown): APIGatewayProxyResult => {
+  if (error instanceof ApiError) {
+    return response(error.statusCode, {
+      error: {
+        code: error.code,
+        message: error.message
+      }
+    });
+  }
+
+  return response(500, {
+    error: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unexpected error occurred.'
+    }
+  });
+};

--- a/backend/shared/types.ts
+++ b/backend/shared/types.ts
@@ -1,0 +1,48 @@
+export type UserRole = 'athlete' | 'coach';
+
+export interface SessionMetrics {
+  durationMinutes: number;
+  intensity: number;
+  rounds: number;
+  giOrNoGi: string;
+  tags: string[];
+}
+
+export interface EntrySections {
+  private: string;
+  shared: string;
+}
+
+export interface Entry {
+  entryId: string;
+  athleteId: string;
+  createdAt: string;
+  updatedAt: string;
+  sections: EntrySections;
+  sessionMetrics: SessionMetrics;
+}
+
+export interface Comment {
+  commentId: string;
+  entryId: string;
+  coachId: string;
+  createdAt: string;
+  body: string;
+  visibility: 'visible' | 'hiddenByAthlete';
+}
+
+export interface CreateEntryRequest {
+  sections: EntrySections;
+  sessionMetrics: SessionMetrics;
+}
+
+export interface PostCommentRequest {
+  entryId: string;
+  body: string;
+}
+
+export interface ApiErrorShape {
+  code: string;
+  message: string;
+  statusCode: number;
+}

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node dist/infrastructure/cdk/bin/app.js"
+}

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -1,0 +1,74 @@
+# API Contracts (v1)
+
+All endpoints require Cognito JWT auth and are fronted by API Gateway REST API.
+
+## `POST /entries`
+Create a training entry.
+- **Role**: `athlete`
+- **Body**:
+```json
+{
+  "sections": {
+    "private": "string",
+    "shared": "string"
+  },
+  "sessionMetrics": {
+    "durationMinutes": 90,
+    "intensity": 7,
+    "rounds": 8,
+    "giOrNoGi": "gi",
+    "tags": ["guard", "sparring"]
+  }
+}
+```
+- **Response**: `201` with `{ entry }`
+
+## `GET /entries`
+Get entries for current athlete.
+- **Role**: `athlete`
+- **Response**: `200` with full entry payloads.
+
+## `GET /athletes/{athleteId}/entries`
+Get entries for linked athlete.
+- **Role**: `coach`
+- **Response**: `200` with shared sections only.
+
+## `POST /entries/comments`
+Post comment on an entry.
+- **Role**: `coach`
+- **Body**:
+```json
+{
+  "entryId": "string",
+  "body": "string"
+}
+```
+- **Response**: `201` with `{ comment }`
+
+## `POST /links/coach`
+Athlete links coach.
+- **Role**: `athlete`
+- **Body**:
+```json
+{
+  "coachId": "string"
+}
+```
+- **Response**: `201` with link confirmation.
+
+## `GET /export`
+Athlete data export.
+- **Role**: `athlete`
+- **Response**: `200` with:
+  - `full`: nested JSON export
+  - `tidy`: normalized arrays for analytics ingestion
+
+## Error format
+```json
+{
+  "error": {
+    "code": "STRING_CODE",
+    "message": "Human readable"
+  }
+}
+```

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,67 @@
+# Roll Model DynamoDB Single-Table Design
+
+## Table
+- **Table name**: `RollModel`
+- **Primary key**:
+  - `PK` (string)
+  - `SK` (string)
+- **Billing mode**: on-demand (`PAY_PER_REQUEST`)
+
+## Entity patterns
+
+### User profile
+- `PK = USER#{userId}`
+- `SK = PROFILE`
+
+Stores identity and preferences controlled by the athlete.
+
+### Coach-athlete link
+- `PK = USER#{athleteId}`
+- `SK = COACH#{coachId}`
+
+Represents an athlete-authorized relationship that grants read/comment access to shared sections.
+
+### Entry
+- `PK = USER#{athleteId}`
+- `SK = ENTRY#{ISODate}#{entryId}`
+
+Entry attributes:
+- `entryId`
+- `athleteId`
+- `createdAt`
+- `updatedAt`
+- `sections`
+  - `private: string`
+  - `shared: string`
+- `sessionMetrics`
+  - `durationMinutes: number`
+  - `intensity: number`
+  - `rounds: number`
+  - `giOrNoGi: string`
+  - `tags: string[]`
+
+### Comment
+- `PK = ENTRY#{entryId}`
+- `SK = COMMENT#{ISODate}#{commentId}`
+
+Comment attributes:
+- `commentId`
+- `entryId`
+- `coachId`
+- `createdAt`
+- `body`
+- `visibility: visible | hiddenByAthlete`
+
+## Supporting access pattern item
+To efficiently validate comment permissions, the backend also stores:
+- `PK = ENTRY#{entryId}`
+- `SK = META`
+- attributes: `athleteId`, `createdAt`
+
+This allows `postComment` to resolve the athlete owner from `entryId`, then verify `COACH` link existence.
+
+## Access patterns implemented
+1. Athlete gets own entries by querying `PK = USER#{athleteId}`, `begins_with(SK, ENTRY#)`.
+2. Coach gets linked athlete entries with the same query after link validation.
+3. Coach posts comment by checking `ENTRY#{entryId}/META` and `USER#{athleteId}/COACH#{coachId}`.
+4. Athlete exports full data by querying own entries plus comments per `ENTRY#{entryId}` partition.

--- a/infrastructure/cdk/bin/app.ts
+++ b/infrastructure/cdk/bin/app.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+
+import { RollModelStack } from '../lib/roll-model-stack';
+
+const app = new cdk.App();
+
+new RollModelStack(app, 'RollModelStack', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
+});

--- a/infrastructure/cdk/lib/roll-model-stack.ts
+++ b/infrastructure/cdk/lib/roll-model-stack.ts
@@ -1,0 +1,143 @@
+import * as path from 'path';
+
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+
+export class RollModelStack extends cdk.Stack {
+  public constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const table = new dynamodb.Table(this, 'RollModelTable', {
+      tableName: 'RollModel',
+      partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN
+    });
+
+    const userPool = new cognito.UserPool(this, 'RollModelUserPool', {
+      selfSignUpEnabled: true,
+      signInAliases: {
+        email: true
+      },
+      autoVerify: {
+        email: true
+      },
+      standardAttributes: {
+        email: {
+          required: true,
+          mutable: false
+        }
+      },
+      customAttributes: {
+        role: new cognito.StringAttribute({
+          minLen: 5,
+          maxLen: 7,
+          mutable: true
+        })
+      },
+      passwordPolicy: {
+        minLength: 12,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true
+      }
+    });
+
+    const userPoolClient = new cognito.UserPoolClient(this, 'RollModelUserPoolClient', {
+      userPool,
+      authFlows: {
+        userPassword: true,
+        userSrp: true
+      }
+    });
+
+    const createEntryLambda = this.createLambda('createEntry', 'backend/lambdas/createEntry/index.ts', table);
+    const getEntriesLambda = this.createLambda('getEntries', 'backend/lambdas/getEntries/index.ts', table);
+    const postCommentLambda = this.createLambda('postComment', 'backend/lambdas/postComment/index.ts', table);
+    const linkCoachAthleteLambda = this.createLambda(
+      'linkCoachAthlete',
+      'backend/lambdas/linkCoachAthlete/index.ts',
+      table
+    );
+    const exportDataLambda = this.createLambda('exportData', 'backend/lambdas/exportData/index.ts', table);
+
+    const api = new apigateway.RestApi(this, 'RollModelApi', {
+      restApiName: 'RollModelApi',
+      deployOptions: {
+        stageName: 'prod'
+      }
+    });
+
+    const authorizer = new apigateway.CognitoUserPoolsAuthorizer(this, 'RollModelAuthorizer', {
+      cognitoUserPools: [userPool],
+      authorizerName: 'RollModelCognitoAuthorizer'
+    });
+
+    const methodOptions: apigateway.MethodOptions = {
+      authorizationType: apigateway.AuthorizationType.COGNITO,
+      authorizer
+    };
+
+    const entries = api.root.addResource('entries');
+    entries.addMethod('POST', new apigateway.LambdaIntegration(createEntryLambda), methodOptions);
+    entries.addMethod('GET', new apigateway.LambdaIntegration(getEntriesLambda), methodOptions);
+
+    const comments = entries.addResource('comments');
+    comments.addMethod('POST', new apigateway.LambdaIntegration(postCommentLambda), methodOptions);
+
+    const links = api.root.addResource('links');
+    const athleteCoach = links.addResource('coach');
+    athleteCoach.addMethod('POST', new apigateway.LambdaIntegration(linkCoachAthleteLambda), methodOptions);
+
+    const exportResource = api.root.addResource('export');
+    exportResource.addMethod('GET', new apigateway.LambdaIntegration(exportDataLambda), methodOptions);
+
+    const athletes = api.root.addResource('athletes');
+    const athleteById = athletes.addResource('{athleteId}');
+    const athleteEntries = athleteById.addResource('entries');
+    athleteEntries.addMethod('GET', new apigateway.LambdaIntegration(getEntriesLambda), methodOptions);
+
+    new cdk.CfnOutput(this, 'ApiUrl', {
+      value: api.url
+    });
+
+    new cdk.CfnOutput(this, 'UserPoolId', {
+      value: userPool.userPoolId
+    });
+
+    new cdk.CfnOutput(this, 'UserPoolClientId', {
+      value: userPoolClient.userPoolClientId
+    });
+
+    new cdk.CfnOutput(this, 'TableName', {
+      value: table.tableName
+    });
+  }
+
+  private createLambda(name: string, entryPath: string, table: dynamodb.Table): nodejs.NodejsFunction {
+    const fn = new nodejs.NodejsFunction(this, `${name}Lambda`, {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'handler',
+      entry: path.join(__dirname, '..', '..', '..', entryPath),
+      environment: {
+        TABLE_NAME: table.tableName
+      },
+      bundling: {
+        target: 'node20',
+        minify: true,
+        sourceMap: false
+      }
+    });
+
+    table.grantReadWriteData(fn);
+    return fn;
+  }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/backend'],
+  testMatch: ['**/*.test.ts'],
+  clearMocks: true
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "roll-model",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Serverless backend for roll-model training intelligence platform.",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist coverage cdk.out",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write .",
+    "test": "jest --runInBand",
+    "cdk:synth": "npm run build && cdk synth -a \"node dist/infrastructure/cdk/bin/app.js\"",
+    "cdk:deploy": "npm run build && cdk deploy -a \"node dist/infrastructure/cdk/bin/app.js\""
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.863.0",
+    "@aws-sdk/lib-dynamodb": "^3.863.0",
+    "aws-cdk-lib": "^2.209.1",
+    "constructs": "^10.4.2",
+    "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.147",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.15.30",
+    "@types/uuid": "^10.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.35.1",
+    "@typescript-eslint/parser": "^8.35.1",
+    "aws-cdk": "^2.1029.1",
+    "esbuild": "^0.25.6",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "jest": "^30.0.5",
+    "prettier": "^3.6.2",
+    "ts-jest": "^29.4.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node", "jest", "aws-lambda"]
+  },
+  "include": ["backend/**/*.ts", "infrastructure/cdk/**/*.ts", "jest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a production-grade TypeScript serverless backend scaffold for the roll-model platform that enforces athlete-owned data, coach read/comment-only access, structured-first storage, and JSON export readiness.

### Description
- Scaffolding and toolchain: added `package.json`, `tsconfig.json`, `jest.config.ts`, `cdk.json`, ESLint (`.eslintrc.cjs`) and Prettier (`.prettierrc`) configuration and root scripts for `build`, `test`, `lint`, `cdk:synth`, and `cdk:deploy`.
- Shared backend primitives: implemented `backend/shared/auth.ts` for JWT claim extraction and role enforcement, `backend/shared/db.ts` for a `DynamoDBDocumentClient` wrapper with `putItem`/`getItem`/`queryItems`, `backend/shared/responses.ts` for standardized `response`/`errorResponse` and `ApiError`, and typed shapes in `backend/shared/types.ts`.
- Lambda handlers: implemented TypeScript Lambda functions for `createEntry`, `getEntries`, `postComment`, `linkCoachAthlete`, and `exportData` with strict role checks, DynamoDB single-table access patterns, coach-athlete link validation, comment creation, and export shaping (both `full` and `tidy`).
- Infrastructure: added a CDK v2 app and stack at `infrastructure/cdk` that provisions the `RollModel` DynamoDB table (PK/SK, on-demand), a Cognito `UserPool` with a `custom:role` attribute, API Gateway REST API with a Cognito authorizer, Node 20 `NodejsFunction` Lambdas for each handler, and grants Lambda read/write access to the table via `table.grantReadWriteData(fn)`.
- Docs and examples: added `docs/data-model.md` describing the single-table design and access patterns, `docs/api-contracts.md` for API contracts, a `README.md` with overview and CDK deploy instructions, and a unit test `backend/lambdas/createEntry/index.test.ts` for the `buildEntry` helper.

### Testing
- A minimal Jest unit test `backend/lambdas/createEntry/index.test.ts` was added to validate `buildEntry` shape.
- Attempted dependency install and local validation (ran `npm install`), but `npm install` failed in this environment with a `403 Forbidden` from the npm registry, so `npm run build`, `npm test`, and `npm run lint` could not be executed here.
- Code was committed and a PR was created (commit short id `e67d844`); remaining automated build/test should be run in CI or a local environment with registry access to complete validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996200b7050832cabb86ee8c1d417b1)