### PR TITLE
Add Codex setup script to auto-configure git origin remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ Reference docs:
 
 ```bash
 npm ci
+npm run setup:codex
 npm run lint
 npm run test
 npm run build
 ```
+
+`npm run setup:codex` configures `origin` automatically when a remote URL is available in environment variables such as `CODEX_GIT_REMOTE_URL`, `CODEX_REMOTE_URL`, `GIT_REMOTE_URL`, `REPOSITORY_URL`, or `GITHUB_REPOSITORY`.
 
 ### Run frontend
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:backend": "jest --runInBand",
     "test:frontend": "npm --prefix frontend run test",
     "cdk:synth": "npm run build && cdk synth -a \"node dist/infrastructure/cdk/bin/app.js\"",
-    "cdk:deploy": "npm run build && cdk deploy -a \"node dist/infrastructure/cdk/bin/app.js\""
+    "cdk:deploy": "npm run build && cdk deploy -a \"node dist/infrastructure/cdk/bin/app.js\"",
+    "setup:codex": "bash scripts/codex/setup-environment.sh"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.863.0",

--- a/scripts/codex/setup-environment.sh
+++ b/scripts/codex/setup-environment.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+resolve_remote_url() {
+  local url=""
+
+  for candidate in "${CODEX_GIT_REMOTE_URL:-}" "${CODEX_REMOTE_URL:-}" "${GIT_REMOTE_URL:-}" "${REPOSITORY_URL:-}"; do
+    if [[ -n "${candidate}" ]]; then
+      url="${candidate}"
+      break
+    fi
+  done
+
+  if [[ -z "${url}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+    local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+    url="${server_url%/}/${GITHUB_REPOSITORY}.git"
+  fi
+
+  printf '%s' "${url}"
+}
+
+main() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Not a git repository; skipping remote setup."
+    return 0
+  fi
+
+  local remote_url
+  remote_url="$(resolve_remote_url)"
+
+  if [[ -z "${remote_url}" ]]; then
+    echo "No remote URL found in environment; skipping remote setup."
+    return 0
+  fi
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    local existing_url
+    existing_url="$(git remote get-url origin)"
+
+    if [[ "${existing_url}" == "${remote_url}" ]]; then
+      echo "Origin remote already configured: ${existing_url}"
+      return 0
+    fi
+
+    git remote set-url origin "${remote_url}"
+    echo "Updated origin remote to ${remote_url}"
+    return 0
+  fi
+
+  git remote add origin "${remote_url}"
+  echo "Added origin remote: ${remote_url}"
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation
- Ensure the development environment setup automatically configures a Git `origin` remote when a repository URL is available in environment variables so non-interactive Codex environments get a usable remote without manual steps.

### Description
- Add `scripts/codex/setup-environment.sh` which discovers a remote URL from `CODEX_GIT_REMOTE_URL`, `CODEX_REMOTE_URL`, `GIT_REMOTE_URL`, `REPOSITORY_URL`, or `GITHUB_REPOSITORY` (with optional `GITHUB_SERVER_URL`) and prints it.
- Make the script add `origin` when missing or update `origin` via `git remote add origin` / `git remote set-url origin` when the configured URL differs, and no-op safely when not in a git repo or no remote is available.
- Add `setup:codex` npm script in `package.json` to run the script and update `README.md` to include `npm run setup:codex` and document supported environment variables.

### Testing
- Ran `bash scripts/codex/setup-environment.sh` inside the repository where no remote env was present and it exited cleanly with a skip message, which succeeded.
- Validated remote addition with `tmpdir=$(mktemp -d) && cd "$tmpdir" && git init -q && CODEX_GIT_REMOTE_URL='https://github.com/example/repo.git' bash /workspace/roll-model/scripts/codex/setup-environment.sh && git remote -v` and observed `origin` added, which succeeded.
- Executed `npm run setup:codex` in the repo to confirm the npm entrypoint runs the script, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb62a404c832c9598a1efc650922a)